### PR TITLE
setConfig function added for changing config parameters instantly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/.DS_Store
 .idea
 .php_cs.cache
+composer.lock
+vendor

--- a/src/Ardakilic/Mutlucell/Mutlucell.php
+++ b/src/Ardakilic/Mutlucell/Mutlucell.php
@@ -33,6 +33,8 @@ class Mutlucell
 
     /**
      * @param array $config
+     *
+     * @return $this
      */
     public function setConfig(array $config)
     {
@@ -47,6 +49,8 @@ class Mutlucell
         if (!isset($this->config['append_unsubscribe_link'])) {
             $this->config['append_unsubscribe_link'] = false;
         }
+
+        return $this;
     }
 
     /**

--- a/src/Ardakilic/Mutlucell/Mutlucell.php
+++ b/src/Ardakilic/Mutlucell/Mutlucell.php
@@ -28,7 +28,15 @@ class Mutlucell
         $this->app = $app;
         $locale = $app['config']['app.locale'];
         $this->lang = $app['translator']->get("mutlucell::{$locale}");
-        $this->config = $app['config']['mutlucell'];
+        $this->setConfig($app['config']['mutlucell']);
+    }
+
+    /**
+     * @param array $config
+     */
+    public function setConfig(array $config)
+    {
+        $this->config = $config;
         $this->senderID = $this->config['default_sender'];
 
         // To prevent missing configuration files to throw exception.
@@ -40,7 +48,6 @@ class Mutlucell
             $this->config['append_unsubscribe_link'] = false;
         }
     }
-
 
     /**
      * Send same bulk message to many people
@@ -120,7 +127,6 @@ class Mutlucell
      */
     public function sendMulti($reciversMessage, $date = '', $senderID = '')
     {
-
         //Pre-checks act1
         if ($senderID == null || !strlen(trim($senderID))) {
             $senderID = $this->config['default_sender'];
@@ -156,7 +162,6 @@ class Mutlucell
      */
     public function sendMulti2($reciversMessage, $date = '', $senderID = '')
     {
-
         //Pre-checks act1
         if ($senderID == null || !strlen(trim($senderID))) {
             $senderID = $this->config['default_sender'];


### PR DESCRIPTION
#5 için güncelleme. 

Kullanım şekli:

```php
\Mutlucell::setConfig([
    'auth' => ['username'=>$usernameFromDb, 'password'=>$passwordFromDb],
    'default_sender' => $aSenderIdThatComesFromSpace,
])->sendBulk($gsmNumbers, $kandilMesaji);
```

