### PR TITLE
add message id and message report methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ if(Mutlucell::getStatus($send)) {
 }
 ```
 
+#### Mutlucell SMS ID
+
+Gönderilen mesajın durumunu (karşı tarafa ulaşıp ulaşmadığı) takip edebilmeniz için SMS ID değerine ihtiyacınız var. 
+
+Aşağıdaki şekilde, SMS ID edinip, daha sonra bununla sorgulama yapabilirsiniz. 
+
+```php
+$send = Mutlucell::send('05312345678', 'Merhaba');
+if(Mutlucell::getStatus($send)) {
+    $messageId = Mutlucell::getMessageId($send);
+    echo 'SMS başarı ile gönderildi! SMS ID: '. $messageId;
+} else {
+    echo 'SMS gönderilemedi';
+}
+```
+
 #### Birden fazla kişiye aynı anda aynı SMS'i göndermek için:
 
 ```php
@@ -113,6 +129,19 @@ $kisiMesajlar = [
 ];
 $send = Mutlucell::sendMulti2($kisiMesajlar);
 var_dump(Mutlucell::parseOutput($send));
+```
+
+#### Gönderilen mesajın durumunu sorgulamak için:
+
+```bash
+>>> \Mutlucell::getMessageReport('1234567890');
+=> [
+     [
+       "number" => "905321234567",
+       "result" => "3",
+       "result_text" => "Başarılı",
+     ],
+   ]
 ```
 
 #### Bir veya birden Fazla Kullanıcıyı Kara Listeye Eklemek İçin

--- a/src/Ardakilic/Mutlucell/Mutlucell.php
+++ b/src/Ardakilic/Mutlucell/Mutlucell.php
@@ -303,6 +303,47 @@ class Mutlucell
         return $this->postXML($xml, 'https://smsgw.mutlucell.com/smsgw-ws/gtorgex');
     }
 
+    /**
+     * @param $messageId
+     *
+     * @return array|string
+     */
+    public function getMessageReport($messageId)
+    {
+        $originatorsXML = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><smsrapor/>');
+        $originatorsXML->addAttribute('ka', $this->config['auth']['username']);
+        $originatorsXML->addAttribute('pwd', $this->config['auth']['password']);
+        $originatorsXML->addAttribute('id', $messageId);
+        $xml = $originatorsXML->asXML();
+
+        $result = $this->postXML($xml, 'https://smsgw.mutlucell.com/smsgw-ws/gtblkrprtex');
+        if ($this->isnum($result)) {
+            switch ($result) {
+                case 20:
+                    return $this->lang['reports']['20'];
+                    break;
+                case 23:
+                    return $this->lang['reports']['23'];
+                    break;
+                case 30:
+                    return $this->lang['reports']['30'];
+                    break;
+            }
+        } else {
+            $messages = array_filter(explode("\n", $result));
+            $report = [];
+            foreach ($messages as $message) {
+                $message = explode(' ', $message);
+                $report[] = [
+                    'number' => $message[0],
+                    'result' => $message[1],
+                    'result_text' => $this->lang['sms'][$message[1]] ?? 'Unknown',
+                ];
+            }
+
+            return $report;
+        }
+    }
 
     /**
      * Parse the output
@@ -411,6 +452,24 @@ class Mutlucell
         } else {
             return false;
         }
+    }
+
+    /**
+     * @param $output
+     *
+     * @return string|null
+     */
+    public function getMessageId($output)
+    {
+        if (preg_match('/(\$[0-9]+\#[0-9]+\.[0-9]+)/i', $output)) {
+            //returned output is formatted like $ID#STATUS
+            //E.g: $1234567#1.0
+            $output = explode('#', $output);
+
+            return str_replace('$', '', $output[0]);
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Gönderilen mesajın ID değerini edinme ve bu değer ile rapor sorgulaması eklendi. 

Not: Rapor methodunun `array|string` olarak dönmesi hiç içime sinmedi. Belki bir iyileştirme yapmamız gerekebilir. 