### PR TITLE
added 8.0 into required php versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": "^7.3",
+    "php": "^7.3|^8.0",
     "illuminate/support": "8.*",
     "guzzlehttp/guzzle": "^6.3.1|^7.0",
     "ext-simplexml": "*"


### PR DESCRIPTION
The error below occurs on composer require, update, etc. on PHP 8 versioned system;

Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - ardakilic/mutlucell is locked to version 5.1.0 and an update of this package was not requested.
    - ardakilic/mutlucell 5.1.0 requires php ^7.3 -> your php version (8.0.1) does not satisfy that requirement.


Installation failed, reverting ./composer.json and ./composer.lock to their original content.